### PR TITLE
Add ability to exclude certain characters from conversion

### DIFF
--- a/src/mariten/kanatools/KanaConverter.java
+++ b/src/mariten/kanatools/KanaConverter.java
@@ -94,6 +94,14 @@ public class KanaConverter
                 next_char = original_string.charAt(i + 1);
             }
 
+            // Skip all conversions if character is on the excluded chars list
+            boolean is_ignore_char = isIgnoreChar(current_char, chars_to_ignore);
+            if(is_ignore_char) {
+                new_string.append(current_char);
+                i++;
+                continue;
+            }
+
             // Order of conversion operations written to be similar to original PHP
             //// Source: https://github.com/php/php-src/blob/128eda843f7dff487fff529a384fee3c5494e0f6/ext/mbstring/libmbfl/filters/mbfilter_tl_jisx0201_jisx0208.c#L41
             if(current_char == this_char
@@ -725,6 +733,23 @@ public class KanaConverter
         } else {
             return target;
         }
+    }
+    //}}}
+
+
+    //{{{ boolean isIgnoreChar(char, String)
+    protected static boolean isIgnoreChar(char char_to_check, String chars_to_ignore)
+    {
+        int ignore_char_count = chars_to_ignore.length();
+        for(int i = 0; i < ignore_char_count; i++) {
+            if(char_to_check == chars_to_ignore.charAt(i)) {
+                // Matched
+                return true;
+            }
+        }
+
+        // No matches
+        return false;
     }
     //}}}
 

--- a/src/mariten/kanatools/KanaConverter.java
+++ b/src/mariten/kanatools/KanaConverter.java
@@ -52,16 +52,17 @@ public class KanaConverter
     }
 
 
-    //{{{ String convertKana(String, int)
+    //{{{ String convertKana(String, int, String)
     /**
       * Converts a string containing kana or other characters used in Japanese text input
       * according to one or more requested conversion methods.
       *
       * @param  original_string  Input string to perform conversion on
       * @param  conversion_ops   Flag-based integer indicating which type of conversions to perform
+      * @param  chars_to_ignore  Each character in this string will be excluded from conversion
       * @return Content of "original_string" with specified conversions performed
       */
-    public static String convertKana(String original_string, int conversion_ops)
+    public static String convertKana(String original_string, int conversion_ops, String chars_to_ignore)
     {
         // Don't perform conversions on empty string
         if(original_string.equals("")) {
@@ -218,18 +219,37 @@ public class KanaConverter
     }
     //}}}
 
-    //{{{ String convertKana(String, String)
+    //{{{ String convertKana(String, int)
+    /**
+      * Same as "convertKana()" above, but defaults to no ignored characters
+      */
+    public static String convertKana(String original_string, int conversion_ops)
+    {
+        return convertKana(original_string, conversion_ops, "");
+    }
+    //}}}
+    //{{{ String convertKana(String, String, String)
     /**
       * Same as "convertKana()" above, but takes the conversion ops as a string (PHP-style)
       *
       * @param  original_string         Input string to perform conversion on
       * @param  conversion_op_string    PHP mb_convert_kana style string specifying desired conversions
+      * @param  chars_to_ignore         Each character in this string will be excluded from conversion
       * @return                         original_string with specified conversion performed
+      */
+    public static String convertKana(String original_string, String conversion_ops_string, String chars_to_ignore)
+    {
+        int conversion_ops = createOpsArrayFromString(conversion_ops_string);
+        return convertKana(original_string, conversion_ops, chars_to_ignore);
+    }
+    //}}}
+    //{{{ String convertKana(String, String)
+    /**
+      * Same as "convertKana()" above, but takes the conversion ops as a string (PHP-style)
       */
     public static String convertKana(String original_string, String conversion_ops_string)
     {
-        int conversion_ops = createOpsArrayFromString(conversion_ops_string);
-        return convertKana(original_string, conversion_ops);
+        return convertKana(original_string, conversion_ops_string, "");
     }
     //}}}
 

--- a/test/mariten/kanatools/KanaConverterTester.java
+++ b/test/mariten/kanatools/KanaConverterTester.java
@@ -44,7 +44,6 @@ public abstract class KanaConverterTester
         }
     }
     //}}}
-
     //{{{ void assertConverted(String, boolean, String, String)
     protected void assertConverted(String conv_flags_string, boolean execute_php_test, String str_to_convert, String expected_result)
     {
@@ -52,18 +51,30 @@ public abstract class KanaConverterTester
         this.assertConverted(conv_flags, execute_php_test, str_to_convert, expected_result);
     }
     //}}}
-
     //{{{ void assertConverted(int, String, String)
     protected void assertConverted(int conv_flags, String str_to_convert, String expected_result)
     {
         this.assertConverted(conv_flags, this.do_direct_php_testing, str_to_convert, expected_result);
     }
     //}}}
-
     //{{{ void assertConverted(String, String, String)
     protected void assertConverted(String conv_flags_string, String str_to_convert, String expected_result)
     {
         this.assertConverted(conv_flags_string, this.do_direct_php_testing, str_to_convert, expected_result);
+    }
+    //}}}
+    //{{{ void assertConvertedWithExclusions(int, String, String, String)
+    /**
+      * Like "assertConverted()", however allow passing excluded characters and do not test in PHP
+      *
+      * @param  conv_flags        Flag-based integer of conversion options for use by convertKana function
+      * @param  chars_to_ignore   Characters to exclude from conversions
+      * @param  str_to_convert    String to test (pass to convertKana function)
+      * @param  expected_result   Expected results of convertKana function
+      */
+    protected void assertConvertedWithExclusions(int conv_flags, String chars_to_ignore, String str_to_convert, String expected_result)
+    {
+        assertEquals(expected_result, KanaConverter.convertKana(str_to_convert, conv_flags, chars_to_ignore));
     }
     //}}}
 

--- a/test/mariten/kanatools/KanaConverterTests/IgnoreCharsTest.java
+++ b/test/mariten/kanatools/KanaConverterTests/IgnoreCharsTest.java
@@ -1,0 +1,70 @@
+package mariten.kanatools.KanaConverterTests;
+
+import mariten.kanatools.KanaConverter;
+import mariten.kanatools.KanaConverterTester;
+import org.junit.Test;
+
+public class IgnoreCharsTest extends KanaConverterTester
+{
+    //{{{ testAsciiIgnoreChars()
+    @Test
+    public void testAsciiIgnoreChars()
+    {
+        String chars_to_exclude = "ABCＤＥＦ:；";
+        super.assertConvertedWithExclusions(KanaConverter.OP_ZEN_ASCII_TO_HAN_ASCII, chars_to_exclude,
+            "　！＂＃＄％＆＇（）＊＋，－．／０１２３４５６７８９：；＜＝＞？＠ＡＢＣＤＥＦＧＨＩＪＫＬＭＮＯＰＱＲＳＴＵＶＷＸＹＺ［＼］＾＿｀ａｂｃｄｅｆｇｈｉｊｋｌｍｎｏｐｑｒｓｔｕｖｗｘｙｚ｛｜｝～",
+            " !\"#$%&'()*+,-./0123456789:；<=>?@ABCＤＥＦGHIJKLMNOPQRSTUVWXYZ[\\]^_`abcdefghijklmnopqrstuvwxyz{|}～"
+        );
+    }
+    //}}}
+
+
+    //{{{ testKanaIgnoreChars()
+    @Test
+    public void testKanaIgnoreChars()
+    {
+        String chars_to_exclude = "あがサゐゑ";
+        super.assertConvertedWithExclusions(KanaConverter.OP_ZEN_HIRA_TO_ZEN_KATA, chars_to_exclude,
+            "〶 | ぁあぃいぅうぇえぉおかがきぎくぐけげこごさざしじすずせぜそぞただちぢっつづてでとどなにぬねのはばぱひびぴふぶぷへべぺほぼぽまみむめもゃやゅゆょよらりるれろゎわゐゑをん | ゔゕゖゝゞ",
+            "〶 | ァあィイゥウェエォオカがキギクグケゲコゴサザシジスズセゼソゾタダチヂッツヅテデトドナニヌネノハバパヒビピフブプヘベペホボポマミムメモャヤュユョヨラリルレロヮワゐゑヲン | ゔゕゖゝゞ"
+        );
+    }
+    //}}}
+
+
+    //{{{ testHankakuIgnoreChars()
+    @Test
+    public void testHankakuIgnoreChars()
+    {
+        String chars_to_exclude = "｢｣ｱｶﾞサ";
+        super.assertConvertedWithExclusions(KanaConverter.OP_HAN_KATA_TO_ZEN_KATA, chars_to_exclude,
+            "～'｡｢｣､･ｧｨｩｪｫｬｭｮｯｰｱｲｳｴｵｶｷｸｹｺｶﾞｷﾞｸﾞｹﾞｺﾞｻｼｽｾｿｻﾞｼﾞｽﾞｾﾞｿﾞﾀﾁﾂﾃﾄﾀﾞﾁﾞﾂﾞﾃﾞﾄﾞﾅﾆﾇﾈﾉﾊﾋﾌﾍﾎﾊﾞﾋﾞﾌﾞﾍﾞﾎﾞﾊﾟﾋﾟﾌﾟﾍﾟﾎﾟﾏﾐﾑﾒﾓﾔﾕﾖﾗﾘﾙﾚﾛﾜｦﾝﾞﾟﾡ",
+            "～'。｢｣、・ァィゥェォャュョッーｱイウエオｶキクケコｶﾞギグゲゴサシスセソザジズゼゾタチツテトダヂヅデドナニヌネノハヒフヘホバビブベボパピプペポマミムメモヤユヨラリルレロワヲンﾞ゜ﾡ"
+        );
+    }
+    //}}}
+
+
+    //{{{ testIgnoreCharsWithNoMatches()
+    @Test
+    public void testIgnoreCharsWithNoMatches()
+    {
+        String chars_to_exclude = "東京A";
+        int conv_ops = 0;
+        conv_ops |= KanaConverter.OP_ZEN_KATA_TO_ZEN_HIRA;
+        conv_ops |= KanaConverter.OP_ZEN_ASCII_TO_HAN_ASCII;
+
+        // No matches in ignore list
+        super.assertConvertedWithExclusions(conv_ops, chars_to_exclude,
+            "トウキョウトＡＢＣ",
+            "とうきょうとABC"
+        );
+
+        // Ignore list is empty string
+        super.assertConvertedWithExclusions(conv_ops, "",
+            "トウキョウトＡＢＣ",
+            "とうきょうとABC"
+        );
+    }
+    //}}}
+}

--- a/test/mariten/kanatools/KanaConverterTests/MultiOpsTest.java
+++ b/test/mariten/kanatools/KanaConverterTests/MultiOpsTest.java
@@ -44,6 +44,16 @@ public class MultiOpsTest extends KanaConverterTester
             " !0:A^a|\" !0:A^a|\"あがぱゐゔゕゝアガパヰヸヷヵヽ゛。アガパ゛漢 #1;B_b}\\ #1;B_b}\\・きじぴゑゖゞキジピヱヹヶヾ゜・キジピ゜字"
         );
 
+        // han2zen kata-kata, zen2han alphanumeric, with exclusions
+        op_flags = 0;
+        op_flags |= KanaConverter.OP_HAN_KATA_TO_ZEN_KATA;
+        op_flags |= KanaConverter.OP_ZEN_ASCII_TO_HAN_ASCII;
+        String chars_to_exclude = "＂＼";
+        this.assertConvertedWithExclusions(op_flags, chars_to_exclude,
+            " !0:A^a|\"　！０：Ａ＾ａ｜＂あがぱゐゔゕゝアガパヰヸヷヵヽ゛｡ｱｶﾞﾊﾟﾞ漢 #1;B_b}\\　＃１；Ｂ＿ｂ｝＼・きじぴゑゖゞキジピヱヹヶヾ゜･ｷｼﾞﾋﾟﾟ字",
+            " !0:A^a|\" !0:A^a|＂あがぱゐゔゕゝアガパヰヸヷヵヽ゛。アガパ゛漢 #1;B_b}\\ #1;B_b}＼・きじぴゑゖゞキジピヱヹヶヾ゜・キジピ゜字"
+        );
+
         // zen2han hira-kata, zen2han kata-kata
         this.assertConverted("hk",
             " !0:A^a|\"　！０：Ａ＾ａ｜＂あがぱゐゔゕゝアガパヰヸヷヵヽ゛｡ｱｶﾞﾊﾟﾞ漢 #1;B_b}\\　＃１；Ｂ＿ｂ｝＼・きじぴゑゖゞキジピヱヹヶヾ゜･ｷｼﾞﾋﾟﾟ字",


### PR DESCRIPTION
## Summary
* Added an optional parameter `chars_to_ignore` to the `convertKana` function
* This parameter is a String containing zero or more characters to be excluded from conversion
* Every character in the `chars_to_ignore` String will be excluded from conversion if that same char is found in the `original_string` input string parameter.
* If the parameter is an empty String or not passed, no exclusions will be done (normal operation)
* Added and updated unit test code accordingly to test this exclusion logic.

## Relevant Issue
#2 