### PR TITLE
Added `KanaAppraiser`

### DIFF
--- a/build.xml
+++ b/build.xml
@@ -120,12 +120,12 @@
     <!-- Output test details if they fail -->
     <target name="check-for-failed-tests" if="tests_failed">
         <echo message="FAILED UNIT TEST DETAILS:${line.separator}${line.separator}" />
-        <echo message="KanaConverter:" />
         <echo message="---------------------------------------------------------------------------------" />
         <concat>
             <fileset dir="${report_dir}">
                 <include name="*.KanaAppraiserTests.*.txt" />
                 <include name="*.KanaConverterTests.*.txt" />
+                <contains text="FAILED" />
             </fileset>
         </concat>
         <echo message="---------------------------------------------------------------------------------" />

--- a/build.xml
+++ b/build.xml
@@ -91,6 +91,7 @@
                 <formatter type="xml" />
                 <batchtest todir="${report_dir}">
                     <fileset dir="${build_test_dir}">
+                        <include name="**/KanaAppraiserTests/*Test.class" />
                         <include name="**/KanaConverterTests/*Test.class" />
                     </fileset>
                 </batchtest>
@@ -123,6 +124,7 @@
         <echo message="---------------------------------------------------------------------------------" />
         <concat>
             <fileset dir="${report_dir}">
+                <include name="*.KanaAppraiserTests.*.txt" />
                 <include name="*.KanaConverterTests.*.txt" />
             </fileset>
         </concat>

--- a/src/mariten/kanatools/KanaAppraiser.java
+++ b/src/mariten/kanatools/KanaAppraiser.java
@@ -16,6 +16,36 @@ public class KanaAppraiser
     public static final char ZENKAKU_KATAKANA_LAST  = 'ン';             // U+30F3
 
 
+    //// Bounds for Numeric
+    public static final char HANKAKU_NUMBER_FIRST = '0';                // U+0030
+    public static final char HANKAKU_NUMBER_LAST  = '9';                // U+0039
+
+    public static final char ZENKAKU_NUMBER_FIRST = '０';               // U+FF10
+    public static final char ZENKAKU_NUMBER_LAST  = '９';               // U+FF19
+
+
+    //// Bounds for Alphabetic
+    public static final char HANKAKU_LETTER_UPPER_FIRST = 'A';          // U+0041
+    public static final char HANKAKU_LETTER_UPPER_LAST  = 'Z';          // U+005A
+    public static final char HANKAKU_LETTER_LOWER_FIRST = 'a';          // U+0061
+    public static final char HANKAKU_LETTER_LOWER_LAST  = 'z';          // U+007A
+
+    public static final char ZENKAKU_LETTER_UPPER_FIRST = 'Ａ';         // U+FF21
+    public static final char ZENKAKU_LETTER_UPPER_LAST  = 'Ｚ';         // U+FF3A
+    public static final char ZENKAKU_LETTER_LOWER_FIRST = 'ａ';         // U+FF41
+    public static final char ZENKAKU_LETTER_LOWER_LAST  = 'ｚ';         // U+FF5A
+
+
+    // Bounds for All Alphanumeric and Symbol ASCII
+    public static final char HANKAKU_SPACE = ' ';                       // U+0020
+    public static final char HANKAKU_ASCII_FIRST = '!';                 // U+0021
+    public static final char HANKAKU_ASCII_LAST  = '~';                 // U+007E
+
+    public static final char ZENKAKU_SPACE = '　';                      // U+3000
+    public static final char ZENKAKU_ASCII_FIRST = '！';                // U+FF01
+    public static final char ZENKAKU_ASCII_LAST  = '～';                // U+FF5E
+
+
     //{{{ boolean isZenkakuHiragana(char)
     public static boolean isZenkakuHiragana(char eval_char)
     {
@@ -33,6 +63,86 @@ public class KanaAppraiser
     {
         if(eval_char >= ZENKAKU_KATAKANA_FIRST
         && eval_char <= ZENKAKU_KATAKANA_LAST) {
+            return true;
+        }
+        return false;
+    }
+    //}}}
+
+
+    //{{{ boolean isHankakuNumber(char)
+    public static boolean isHankakuNumber(char eval_char)
+    {
+        if(eval_char >= HANKAKU_NUMBER_FIRST
+        && eval_char <= HANKAKU_NUMBER_LAST) {
+            return true;
+        }
+        return false;
+    }
+    //}}}
+
+
+    //{{{ boolean isZenkakuNumber(char)
+    public static boolean isZenkakuNumber(char eval_char)
+    {
+        if(eval_char >= ZENKAKU_NUMBER_FIRST
+        && eval_char <= ZENKAKU_NUMBER_LAST) {
+            return true;
+        }
+        return false;
+    }
+    //}}}
+
+
+    //{{{ boolean isHankakuLetter(char)
+    public static boolean isHankakuLetter(char eval_char)
+    {
+        if(eval_char >= HANKAKU_LETTER_UPPER_FIRST
+        && eval_char <= HANKAKU_LETTER_UPPER_LAST) {
+            return true;
+        }
+        if(eval_char >= HANKAKU_LETTER_LOWER_FIRST
+        && eval_char <= HANKAKU_LETTER_LOWER_LAST) {
+            return true;
+        }
+        return false;
+    }
+    //}}}
+
+
+    //{{{ boolean isZenkakuLetter(char)
+    public static boolean isZenkakuLetter(char eval_char)
+    {
+        if(eval_char >= ZENKAKU_LETTER_UPPER_FIRST
+        && eval_char <= ZENKAKU_LETTER_UPPER_LAST) {
+            return true;
+        }
+        if(eval_char >= ZENKAKU_LETTER_LOWER_FIRST
+        && eval_char <= ZENKAKU_LETTER_LOWER_LAST) {
+            return true;
+        }
+        return false;
+    }
+    //}}}
+
+
+    //{{{ boolean isHankakuAscii(char)
+    public static boolean isHankakuAscii(char eval_char)
+    {
+        if(eval_char >= HANKAKU_ASCII_FIRST
+        && eval_char <= HANKAKU_ASCII_LAST) {
+            return true;
+        }
+        return false;
+    }
+    //}}}
+
+
+    //{{{ boolean isZenkakuAscii(char)
+    public static boolean isZenkakuAscii(char eval_char)
+    {
+        if(eval_char >= ZENKAKU_ASCII_FIRST
+        && eval_char <= ZENKAKU_ASCII_LAST) {
             return true;
         }
         return false;

--- a/src/mariten/kanatools/KanaAppraiser.java
+++ b/src/mariten/kanatools/KanaAppraiser.java
@@ -13,7 +13,8 @@ public class KanaAppraiser
 
     //// Bounds for Katakana
     public static final char ZENKAKU_KATAKANA_FIRST = 'ァ';             // U+30A1
-    public static final char ZENKAKU_KATAKANA_LAST  = 'ン';             // U+30F3
+    public static final char ZENKAKU_KATAKANA_LAST_FOR_MAPPING  = 'ン'; // U+30F3
+    public static final char ZENKAKU_KATAKANA_LAST  = 'ヺ';             // U+30FA
 
 
     //// Bounds for Numeric
@@ -63,6 +64,18 @@ public class KanaAppraiser
     {
         if(eval_char >= ZENKAKU_KATAKANA_FIRST
         && eval_char <= ZENKAKU_KATAKANA_LAST) {
+            return true;
+        }
+        return false;
+    }
+    //}}}
+
+
+    //{{{ boolean isMappableZenkakuKatakana(char)
+    public static boolean isMappableZenkakuKatakana(char eval_char)
+    {
+        if(eval_char >= ZENKAKU_KATAKANA_FIRST
+        && eval_char <= ZENKAKU_KATAKANA_LAST_FOR_MAPPING) {
             return true;
         }
         return false;

--- a/src/mariten/kanatools/KanaAppraiser.java
+++ b/src/mariten/kanatools/KanaAppraiser.java
@@ -1,0 +1,41 @@
+package mariten.kanatools;
+
+/**
+  * Confirms whether a given character is amongst certain types of Japanese text or not.
+  */
+public class KanaAppraiser
+{
+    // Character set lower/upper bound definitions
+    //// Bounds for Hiragana
+    public static final char ZENKAKU_HIRAGANA_FIRST = 'ぁ';             // U+3041
+    public static final char ZENKAKU_HIRAGANA_LAST  = 'ん';             // U+3093
+
+
+    //// Bounds for Katakana
+    public static final char ZENKAKU_KATAKANA_FIRST = 'ァ';             // U+30A1
+    public static final char ZENKAKU_KATAKANA_LAST  = 'ン';             // U+30F3
+
+
+    //{{{ boolean isZenkakuHiragana(char)
+    public static boolean isZenkakuHiragana(char eval_char)
+    {
+        if(eval_char >= ZENKAKU_HIRAGANA_FIRST
+        && eval_char <= ZENKAKU_HIRAGANA_LAST) {
+            return true;
+        }
+        return false;
+    }
+    //}}}
+
+
+    //{{{ boolean isZenkakuKatakana(char)
+    public static boolean isZenkakuKatakana(char eval_char)
+    {
+        if(eval_char >= ZENKAKU_KATAKANA_FIRST
+        && eval_char <= ZENKAKU_KATAKANA_LAST) {
+            return true;
+        }
+        return false;
+    }
+    //}}}
+}

--- a/src/mariten/kanatools/KanaAppraiser.java
+++ b/src/mariten/kanatools/KanaAppraiser.java
@@ -12,6 +12,9 @@ public class KanaAppraiser
 
 
     //// Bounds for Katakana
+    public static final char HANKAKU_KATAKANA_FIRST = 'ｦ';              // U+FF66
+    public static final char HANKAKU_KATAKANA_LAST  = 'ﾝ';              // U+FF9D
+
     public static final char ZENKAKU_KATAKANA_FIRST = 'ァ';             // U+30A1
     public static final char ZENKAKU_KATAKANA_LAST_FOR_MAPPING  = 'ン'; // U+30F3
     public static final char ZENKAKU_KATAKANA_LAST  = 'ヺ';             // U+30FA
@@ -52,6 +55,18 @@ public class KanaAppraiser
     {
         if(eval_char >= ZENKAKU_HIRAGANA_FIRST
         && eval_char <= ZENKAKU_HIRAGANA_LAST) {
+            return true;
+        }
+        return false;
+    }
+    //}}}
+
+
+    //{{{ boolean isHankakuKatakana(char)
+    public static boolean isHankakuKatakana(char eval_char)
+    {
+        if(eval_char >= HANKAKU_KATAKANA_FIRST
+        && eval_char <= HANKAKU_KATAKANA_LAST) {
             return true;
         }
         return false;

--- a/src/mariten/kanatools/KanaConverter.java
+++ b/src/mariten/kanatools/KanaConverter.java
@@ -1,4 +1,5 @@
 package mariten.kanatools;
+import mariten.kanatools.KanaAppraiser;
 
 import java.util.HashMap;
 import java.util.Map;
@@ -282,14 +283,6 @@ public class KanaConverter
     public static final char ZENKAKU_ASCII_FIRST = '！';
     public static final char ZENKAKU_ASCII_LAST  = '～';
 
-    // Hiragana constants
-    public static final char HIRAGANA_FIRST = 'ぁ';
-    public static final char HIRAGANA_LAST  = 'ん';
-
-    // Katakana constants
-    public static final char ZENKAKU_KATAKANA_FIRST = 'ァ';
-    public static final char ZENKAKU_KATAKANA_LAST  = 'ン';
-
     // Diacritic constants
     public static final char HANKAKU_VOICED_MARK    = 'ﾞ';  // dakuten
     public static final char HANKAKU_ASPIRATED_MARK = 'ﾟ';  // handakuten
@@ -534,6 +527,10 @@ public class KanaConverter
     //}}}
 
 
+    // Connect mapping of hiragana and katakana char codes
+    public static final int OFFSET_ZENKAKU_HIRAGANA_TO_ZENKAKU_KATAKANA =
+    (KanaAppraiser.ZENKAKU_KATAKANA_FIRST - KanaAppraiser.ZENKAKU_HIRAGANA_FIRST);
+
     //{{{ char convertHankakuAsciiToZenkakuAscii(char)
     protected static char convertHankakuAsciiToZenkakuAscii(char target)
     {
@@ -565,9 +562,8 @@ public class KanaConverter
     //{{{ char convertZenkakuHiraganaToZenkakuKatakana(char)
     protected static char convertZenkakuHiraganaToZenkakuKatakana(char target)
     {
-        if(target >= HIRAGANA_FIRST && target <= HIRAGANA_LAST) {
-            // Offset by difference in hira/kata kana char-code position
-            return (char)(target + (ZENKAKU_KATAKANA_FIRST - HIRAGANA_FIRST));
+        if(KanaAppraiser.isZenkakuHiragana(target)) {
+            return (char)(target + OFFSET_ZENKAKU_HIRAGANA_TO_ZENKAKU_KATAKANA);
         } else {
             return target;
         }
@@ -578,9 +574,8 @@ public class KanaConverter
     //{{{ char convertZenkakuKatakanaToZenkakuHiragana(char)
     protected static char convertZenkakuKatakanaToZenkakuHiragana(char target)
     {
-        if(target >= ZENKAKU_KATAKANA_FIRST && target <= ZENKAKU_KATAKANA_LAST) {
-            // Offset by difference in hira/kata kana char-code position
-            return (char)(target - (ZENKAKU_KATAKANA_FIRST - HIRAGANA_FIRST));
+        if(KanaAppraiser.isZenkakuKatakana(target)) {
+            return (char)(target - OFFSET_ZENKAKU_HIRAGANA_TO_ZENKAKU_KATAKANA);
         } else {
             return target;
         }

--- a/src/mariten/kanatools/KanaConverter.java
+++ b/src/mariten/kanatools/KanaConverter.java
@@ -260,40 +260,11 @@ public class KanaConverter
     //}}}
 
 
-    //{{{ Character constants
-    // Numeric constants
-    public static final char HANKAKU_NUMBER_FIRST = '0';
-    public static final char HANKAKU_NUMBER_LAST  = '9';
-    public static final char ZENKAKU_NUMBER_FIRST = '０';
-    public static final char ZENKAKU_NUMBER_LAST  = '９';
-
-    // Alphabetic constants
-    public static final char HANKAKU_LETTER_UPPER_FIRST = 'A';
-    public static final char HANKAKU_LETTER_UPPER_LAST  = 'Z';
-    public static final char HANKAKU_LETTER_LOWER_FIRST = 'a';
-    public static final char HANKAKU_LETTER_LOWER_LAST  = 'z';
-    public static final char ZENKAKU_LETTER_UPPER_FIRST = 'Ａ';
-    public static final char ZENKAKU_LETTER_UPPER_LAST  = 'Ｚ';
-    public static final char ZENKAKU_LETTER_LOWER_FIRST = 'ａ';
-    public static final char ZENKAKU_LETTER_LOWER_LAST  = 'ｚ';
-
-    // Punctuation constants
-    public static final char HANKAKU_ASCII_FIRST = '!';
-    public static final char HANKAKU_ASCII_LAST  = '~';
-    public static final char ZENKAKU_ASCII_FIRST = '！';
-    public static final char ZENKAKU_ASCII_LAST  = '～';
-
+    //{{{ Hankaku Katakana related mappings
     // Diacritic constants
     public static final char HANKAKU_VOICED_MARK    = 'ﾞ';  // dakuten
     public static final char HANKAKU_ASPIRATED_MARK = 'ﾟ';  // handakuten
 
-    // Other constants
-    public static final char HANKAKU_SPACE = ' ';
-    public static final char ZENKAKU_SPACE = '　';
-    //}}}
-
-
-    //{{{ Hankaku Katakana related mappings
     protected static final Map<Character, Character> MAPPING_HANKAKU_TO_ZENKAKU_KATAKANA_UNVOICED;
     static {
         MAPPING_HANKAKU_TO_ZENKAKU_KATAKANA_UNVOICED = new HashMap<Character, Character>();
@@ -531,16 +502,21 @@ public class KanaConverter
     public static final int OFFSET_ZENKAKU_HIRAGANA_TO_ZENKAKU_KATAKANA =
     (KanaAppraiser.ZENKAKU_KATAKANA_FIRST - KanaAppraiser.ZENKAKU_HIRAGANA_FIRST);
 
+    // Connect mapping of regular ASCII characters to Zenkaku ASCII characters
+    public static final int OFFSET_HANKAKU_ASCII_TO_ZENKAKU_ASCII =
+    (KanaAppraiser.ZENKAKU_ASCII_FIRST - KanaAppraiser.HANKAKU_ASCII_FIRST);
+
+
     //{{{ char convertHankakuAsciiToZenkakuAscii(char)
     protected static char convertHankakuAsciiToZenkakuAscii(char target)
     {
-        if(target >= HANKAKU_ASCII_FIRST && target <= HANKAKU_ASCII_LAST) {
-            return (char)(target + (ZENKAKU_ASCII_FIRST - HANKAKU_ASCII_FIRST));
-        } else if(target == HANKAKU_SPACE) {
-            return ZENKAKU_SPACE;
+        if(KanaAppraiser.isHankakuAscii(target)) {
+            return (char)(target + OFFSET_HANKAKU_ASCII_TO_ZENKAKU_ASCII);
+        } else if(target == KanaAppraiser.HANKAKU_SPACE) {
+            return KanaAppraiser.ZENKAKU_SPACE;
+        } else {
+            return target;
         }
-
-        return target;
     }
     //}}}
 
@@ -548,13 +524,13 @@ public class KanaConverter
     //{{{ char convertZenkakuAsciiToHankakuAscii(char)
     protected static char convertZenkakuAsciiToHankakuAscii(char target)
     {
-        if(target >= ZENKAKU_ASCII_FIRST && target <= ZENKAKU_ASCII_LAST) {
-            return (char)(target - (ZENKAKU_ASCII_FIRST - HANKAKU_ASCII_FIRST));
-        } else if(target == ZENKAKU_SPACE) {
-            return HANKAKU_SPACE;
+        if(KanaAppraiser.isZenkakuAscii(target)) {
+            return (char)(target - OFFSET_HANKAKU_ASCII_TO_ZENKAKU_ASCII);
+        } else if(target == KanaAppraiser.ZENKAKU_SPACE) {
+            return KanaAppraiser.HANKAKU_SPACE;
+        } else {
+            return target;
         }
-
-        return target;
     }
     //}}}
 
@@ -646,9 +622,9 @@ public class KanaConverter
     //{{{ char convertHankakuNumberToZenkakuNumber(char)
     protected static char convertHankakuNumberToZenkakuNumber(char target)
     {
-        if(target >= HANKAKU_NUMBER_FIRST && target <= HANKAKU_NUMBER_LAST) {
+        if(KanaAppraiser.isHankakuNumber(target)) {
             // Offset by difference in char-code position
-            return (char)(target + (ZENKAKU_NUMBER_FIRST - HANKAKU_NUMBER_FIRST));
+            return (char)(target + OFFSET_HANKAKU_ASCII_TO_ZENKAKU_ASCII);
         } else {
             return target;
         }
@@ -659,9 +635,9 @@ public class KanaConverter
     //{{{ char convertZenkakuNumberToHankakuNumber(char)
     protected static char convertZenkakuNumberToHankakuNumber(char target)
     {
-        if(target >= ZENKAKU_NUMBER_FIRST && target <= ZENKAKU_NUMBER_LAST) {
+        if(KanaAppraiser.isZenkakuNumber(target)) {
             // Offset by difference in char-code position
-            return (char)(target - (ZENKAKU_NUMBER_FIRST - HANKAKU_NUMBER_FIRST));
+            return (char)(target - OFFSET_HANKAKU_ASCII_TO_ZENKAKU_ASCII);
         } else {
             return target;
         }
@@ -672,15 +648,9 @@ public class KanaConverter
     //{{{ char convertHankakuLetterToZenkakuLetter(char)
     protected static char convertHankakuLetterToZenkakuLetter(char target)
     {
-        if(target >= HANKAKU_LETTER_LOWER_FIRST && target <= HANKAKU_LETTER_LOWER_LAST) {
-            // Offset by difference in lower-case char-code position
-            return (char)(target + (ZENKAKU_LETTER_LOWER_FIRST - HANKAKU_LETTER_LOWER_FIRST));
-        }
-        else if(target >= HANKAKU_LETTER_UPPER_FIRST && target <= HANKAKU_LETTER_UPPER_LAST) {
-            // Offset by difference in upper-case char-code position
-            return (char)(target + (ZENKAKU_LETTER_UPPER_FIRST - HANKAKU_LETTER_UPPER_FIRST));
-        }
-        else {
+        if(KanaAppraiser.isHankakuLetter(target)) {
+            return (char)(target + OFFSET_HANKAKU_ASCII_TO_ZENKAKU_ASCII);
+        } else {
             return target;
         }
     }
@@ -690,15 +660,9 @@ public class KanaConverter
     //{{{ char convertZenkakuLetterToHankakuLetter(char)
     protected static char convertZenkakuLetterToHankakuLetter(char target)
     {
-        if(target >= ZENKAKU_LETTER_LOWER_FIRST && target <= ZENKAKU_LETTER_LOWER_LAST) {
-            // Offset by difference in lower-case char-code position
-            return (char)(target - (ZENKAKU_LETTER_LOWER_FIRST - HANKAKU_LETTER_LOWER_FIRST));
-        }
-        else if(target >= ZENKAKU_LETTER_UPPER_FIRST && target <= ZENKAKU_LETTER_UPPER_LAST) {
-            // Offset by difference in upper-case char-code position
-            return (char)(target - (ZENKAKU_LETTER_UPPER_FIRST - HANKAKU_LETTER_UPPER_FIRST));
-        }
-        else {
+        if(KanaAppraiser.isZenkakuLetter(target)) {
+            return (char)(target - OFFSET_HANKAKU_ASCII_TO_ZENKAKU_ASCII);
+        } else {
             return target;
         }
     }
@@ -708,8 +672,8 @@ public class KanaConverter
     //{{{ char convertHankakuSpaceToZenkakuSpace(char)
     protected static char convertHankakuSpaceToZenkakuSpace(char target)
     {
-        if(target == HANKAKU_SPACE) {
-            return ZENKAKU_SPACE;
+        if(target == KanaAppraiser.HANKAKU_SPACE) {
+            return KanaAppraiser.ZENKAKU_SPACE;
         } else {
             return target;
         }
@@ -720,8 +684,8 @@ public class KanaConverter
     //{{{ char convertZenkakuSpaceToHankakuSpace(char)
     protected static char convertZenkakuSpaceToHankakuSpace(char target)
     {
-        if(target == ZENKAKU_SPACE) {
-            return HANKAKU_SPACE;
+        if(target == KanaAppraiser.ZENKAKU_SPACE) {
+            return KanaAppraiser.HANKAKU_SPACE;
         } else {
             return target;
         }

--- a/src/mariten/kanatools/KanaConverter.java
+++ b/src/mariten/kanatools/KanaConverter.java
@@ -550,7 +550,7 @@ public class KanaConverter
     //{{{ char convertZenkakuKatakanaToZenkakuHiragana(char)
     protected static char convertZenkakuKatakanaToZenkakuHiragana(char target)
     {
-        if(KanaAppraiser.isZenkakuKatakana(target)) {
+        if(KanaAppraiser.isMappableZenkakuKatakana(target)) {
             return (char)(target - OFFSET_ZENKAKU_HIRAGANA_TO_ZENKAKU_KATAKANA);
         } else {
             return target;

--- a/test/mariten/kanatools/KanaAppraiserTester.java
+++ b/test/mariten/kanatools/KanaAppraiserTester.java
@@ -1,0 +1,11 @@
+package mariten.kanatools;
+import mariten.kanatools.KanaAppraiser;
+
+public abstract class KanaAppraiserTester
+{
+    public KanaAppraiserTester()
+    {
+        // Test instantiation
+        KanaAppraiser kana_evaluator_object = new KanaAppraiser();
+    }
+}

--- a/test/mariten/kanatools/TestsKanaAppraiser/AsciiBooleanChecksTest.java
+++ b/test/mariten/kanatools/TestsKanaAppraiser/AsciiBooleanChecksTest.java
@@ -1,0 +1,262 @@
+package mariten.kanatools.KanaAppraiserTests;
+import mariten.kanatools.KanaAppraiser;
+import mariten.kanatools.KanaAppraiserTester;
+import org.junit.Test;
+
+import static org.junit.Assert.*;
+
+public class AsciiBooleanChecksTest extends KanaAppraiserTester
+{
+    //{{{ testZenkakuAsciiChecks()
+    @Test
+    public void testZenkakuAsciiChecks()
+    {
+        assertEquals(false, KanaAppraiser.isZenkakuAscii ('　'));
+        assertEquals(false, KanaAppraiser.isZenkakuNumber('　'));
+        assertEquals(false, KanaAppraiser.isZenkakuLetter('　'));
+
+        assertEquals(true,  KanaAppraiser.isZenkakuAscii ('！'));
+        assertEquals(false, KanaAppraiser.isZenkakuNumber('！'));
+        assertEquals(false, KanaAppraiser.isZenkakuLetter('！'));
+
+        assertEquals(true,  KanaAppraiser.isZenkakuAscii ('＂'));
+        assertEquals(false, KanaAppraiser.isZenkakuNumber('＂'));
+        assertEquals(false, KanaAppraiser.isZenkakuLetter('＂'));
+
+        assertEquals(true,  KanaAppraiser.isZenkakuAscii ('．'));
+        assertEquals(false, KanaAppraiser.isZenkakuNumber('．'));
+        assertEquals(false, KanaAppraiser.isZenkakuLetter('．'));
+
+        assertEquals(true,  KanaAppraiser.isZenkakuAscii ('／'));
+        assertEquals(false, KanaAppraiser.isZenkakuNumber('／'));
+        assertEquals(false, KanaAppraiser.isZenkakuLetter('／'));
+
+        assertEquals(true,  KanaAppraiser.isZenkakuAscii ('０'));
+        assertEquals(true,  KanaAppraiser.isZenkakuNumber('０'));
+        assertEquals(false, KanaAppraiser.isZenkakuLetter('０'));
+
+        assertEquals(true,  KanaAppraiser.isZenkakuAscii ('１'));
+        assertEquals(true,  KanaAppraiser.isZenkakuNumber('１'));
+        assertEquals(false, KanaAppraiser.isZenkakuLetter('１'));
+
+        assertEquals(true,  KanaAppraiser.isZenkakuAscii ('８'));
+        assertEquals(true,  KanaAppraiser.isZenkakuNumber('８'));
+        assertEquals(false, KanaAppraiser.isZenkakuLetter('８'));
+
+        assertEquals(true,  KanaAppraiser.isZenkakuAscii ('９'));
+        assertEquals(true,  KanaAppraiser.isZenkakuNumber('９'));
+        assertEquals(false, KanaAppraiser.isZenkakuLetter('９'));
+
+        assertEquals(true,  KanaAppraiser.isZenkakuAscii ('：'));
+        assertEquals(false, KanaAppraiser.isZenkakuNumber('：'));
+        assertEquals(false, KanaAppraiser.isZenkakuLetter('：'));
+
+        assertEquals(true,  KanaAppraiser.isZenkakuAscii ('；'));
+        assertEquals(false, KanaAppraiser.isZenkakuNumber('；'));
+        assertEquals(false, KanaAppraiser.isZenkakuLetter('；'));
+
+        assertEquals(true,  KanaAppraiser.isZenkakuAscii ('？'));
+        assertEquals(false, KanaAppraiser.isZenkakuNumber('？'));
+        assertEquals(false, KanaAppraiser.isZenkakuLetter('？'));
+
+        assertEquals(true,  KanaAppraiser.isZenkakuAscii ('＠'));
+        assertEquals(false, KanaAppraiser.isZenkakuNumber('＠'));
+        assertEquals(false, KanaAppraiser.isZenkakuLetter('＠'));
+
+        assertEquals(true,  KanaAppraiser.isZenkakuAscii ('Ａ'));
+        assertEquals(false, KanaAppraiser.isZenkakuNumber('Ａ'));
+        assertEquals(true,  KanaAppraiser.isZenkakuLetter('Ａ'));
+
+        assertEquals(true,  KanaAppraiser.isZenkakuAscii ('Ｂ'));
+        assertEquals(false, KanaAppraiser.isZenkakuNumber('Ｂ'));
+        assertEquals(true,  KanaAppraiser.isZenkakuLetter('Ｂ'));
+
+        assertEquals(true,  KanaAppraiser.isZenkakuAscii ('Ｙ'));
+        assertEquals(false, KanaAppraiser.isZenkakuNumber('Ｙ'));
+        assertEquals(true,  KanaAppraiser.isZenkakuLetter('Ｙ'));
+
+        assertEquals(true,  KanaAppraiser.isZenkakuAscii ('Ｚ'));
+        assertEquals(false, KanaAppraiser.isZenkakuNumber('Ｚ'));
+        assertEquals(true,  KanaAppraiser.isZenkakuLetter('Ｚ'));
+
+        assertEquals(true,  KanaAppraiser.isZenkakuAscii ('［'));
+        assertEquals(false, KanaAppraiser.isZenkakuNumber('［'));
+        assertEquals(false, KanaAppraiser.isZenkakuLetter('［'));
+
+        assertEquals(true,  KanaAppraiser.isZenkakuAscii ('＼'));
+        assertEquals(false, KanaAppraiser.isZenkakuNumber('＼'));
+        assertEquals(false, KanaAppraiser.isZenkakuLetter('＼'));
+
+        assertEquals(true,  KanaAppraiser.isZenkakuAscii ('＿'));
+        assertEquals(false, KanaAppraiser.isZenkakuNumber('＿'));
+        assertEquals(false, KanaAppraiser.isZenkakuLetter('＿'));
+
+        assertEquals(true,  KanaAppraiser.isZenkakuAscii ('｀'));
+        assertEquals(false, KanaAppraiser.isZenkakuNumber('｀'));
+        assertEquals(false, KanaAppraiser.isZenkakuLetter('｀'));
+
+        assertEquals(true,  KanaAppraiser.isZenkakuAscii ('ａ'));
+        assertEquals(false, KanaAppraiser.isZenkakuNumber('ａ'));
+        assertEquals(true,  KanaAppraiser.isZenkakuLetter('ａ'));
+
+        assertEquals(true,  KanaAppraiser.isZenkakuAscii ('ｂ'));
+        assertEquals(false, KanaAppraiser.isZenkakuNumber('ｂ'));
+        assertEquals(true,  KanaAppraiser.isZenkakuLetter('ｂ'));
+
+        assertEquals(true,  KanaAppraiser.isZenkakuAscii ('ｙ'));
+        assertEquals(false, KanaAppraiser.isZenkakuNumber('ｙ'));
+        assertEquals(true,  KanaAppraiser.isZenkakuLetter('ｙ'));
+
+        assertEquals(true,  KanaAppraiser.isZenkakuAscii ('ｚ'));
+        assertEquals(false, KanaAppraiser.isZenkakuNumber('ｚ'));
+        assertEquals(true,  KanaAppraiser.isZenkakuLetter('ｚ'));
+
+        assertEquals(true,  KanaAppraiser.isZenkakuAscii ('｛'));
+        assertEquals(false, KanaAppraiser.isZenkakuNumber('｛'));
+        assertEquals(false, KanaAppraiser.isZenkakuLetter('｛'));
+
+        assertEquals(true,  KanaAppraiser.isZenkakuAscii ('｜'));
+        assertEquals(false, KanaAppraiser.isZenkakuNumber('｜'));
+        assertEquals(false, KanaAppraiser.isZenkakuLetter('｜'));
+
+        assertEquals(true,  KanaAppraiser.isZenkakuAscii ('｝'));
+        assertEquals(false, KanaAppraiser.isZenkakuNumber('｝'));
+        assertEquals(false, KanaAppraiser.isZenkakuLetter('｝'));
+
+        assertEquals(true,  KanaAppraiser.isZenkakuAscii ('～'));
+        assertEquals(false, KanaAppraiser.isZenkakuNumber('～'));
+        assertEquals(false, KanaAppraiser.isZenkakuLetter('～'));
+
+        assertEquals(false, KanaAppraiser.isZenkakuAscii ('｟'));
+        assertEquals(false, KanaAppraiser.isZenkakuNumber('｟'));
+        assertEquals(false, KanaAppraiser.isZenkakuLetter('｟'));
+    }
+    //}}}
+
+
+    //{{{ testHankakuAsciiChecks()
+    @Test
+    public void testHankakuAsciiChecks()
+    {
+        assertEquals(false, KanaAppraiser.isHankakuAscii (' '));
+        assertEquals(false, KanaAppraiser.isHankakuNumber(' '));
+        assertEquals(false, KanaAppraiser.isHankakuLetter(' '));
+
+        assertEquals(true,  KanaAppraiser.isHankakuAscii ('!'));
+        assertEquals(false, KanaAppraiser.isHankakuNumber('!'));
+        assertEquals(false, KanaAppraiser.isHankakuLetter('!'));
+
+        assertEquals(true,  KanaAppraiser.isHankakuAscii ('"'));
+        assertEquals(false, KanaAppraiser.isHankakuNumber('"'));
+        assertEquals(false, KanaAppraiser.isHankakuLetter('"'));
+
+        assertEquals(true,  KanaAppraiser.isHankakuAscii ('.'));
+        assertEquals(false, KanaAppraiser.isHankakuNumber('.'));
+        assertEquals(false, KanaAppraiser.isHankakuLetter('.'));
+
+        assertEquals(true,  KanaAppraiser.isHankakuAscii ('/'));
+        assertEquals(false, KanaAppraiser.isHankakuNumber('/'));
+        assertEquals(false, KanaAppraiser.isHankakuLetter('/'));
+
+        assertEquals(true,  KanaAppraiser.isHankakuAscii ('0'));
+        assertEquals(true,  KanaAppraiser.isHankakuNumber('0'));
+        assertEquals(false, KanaAppraiser.isHankakuLetter('0'));
+
+        assertEquals(true,  KanaAppraiser.isHankakuAscii ('1'));
+        assertEquals(true,  KanaAppraiser.isHankakuNumber('1'));
+        assertEquals(false, KanaAppraiser.isHankakuLetter('1'));
+
+        assertEquals(true,  KanaAppraiser.isHankakuAscii ('8'));
+        assertEquals(true,  KanaAppraiser.isHankakuNumber('8'));
+        assertEquals(false, KanaAppraiser.isHankakuLetter('8'));
+
+        assertEquals(true,  KanaAppraiser.isHankakuAscii ('9'));
+        assertEquals(true,  KanaAppraiser.isHankakuNumber('9'));
+        assertEquals(false, KanaAppraiser.isHankakuLetter('9'));
+
+        assertEquals(true,  KanaAppraiser.isHankakuAscii (':'));
+        assertEquals(false, KanaAppraiser.isHankakuNumber(':'));
+        assertEquals(false, KanaAppraiser.isHankakuLetter(':'));
+
+        assertEquals(true,  KanaAppraiser.isHankakuAscii (';'));
+        assertEquals(false, KanaAppraiser.isHankakuNumber(';'));
+        assertEquals(false, KanaAppraiser.isHankakuLetter(';'));
+
+        assertEquals(true,  KanaAppraiser.isHankakuAscii ('?'));
+        assertEquals(false, KanaAppraiser.isHankakuNumber('?'));
+        assertEquals(false, KanaAppraiser.isHankakuLetter('?'));
+
+        assertEquals(true,  KanaAppraiser.isHankakuAscii ('@'));
+        assertEquals(false, KanaAppraiser.isHankakuNumber('@'));
+        assertEquals(false, KanaAppraiser.isHankakuLetter('@'));
+
+        assertEquals(true,  KanaAppraiser.isHankakuAscii ('A'));
+        assertEquals(false, KanaAppraiser.isHankakuNumber('A'));
+        assertEquals(true,  KanaAppraiser.isHankakuLetter('A'));
+
+        assertEquals(true,  KanaAppraiser.isHankakuAscii ('B'));
+        assertEquals(false, KanaAppraiser.isHankakuNumber('B'));
+        assertEquals(true,  KanaAppraiser.isHankakuLetter('B'));
+
+        assertEquals(true,  KanaAppraiser.isHankakuAscii ('Y'));
+        assertEquals(false, KanaAppraiser.isHankakuNumber('Y'));
+        assertEquals(true,  KanaAppraiser.isHankakuLetter('Y'));
+
+        assertEquals(true,  KanaAppraiser.isHankakuAscii ('Z'));
+        assertEquals(false, KanaAppraiser.isHankakuNumber('Z'));
+        assertEquals(true,  KanaAppraiser.isHankakuLetter('Z'));
+
+        assertEquals(true,  KanaAppraiser.isHankakuAscii ('['));
+        assertEquals(false, KanaAppraiser.isHankakuNumber('['));
+        assertEquals(false, KanaAppraiser.isHankakuLetter('['));
+
+        assertEquals(true,  KanaAppraiser.isHankakuAscii ('\\'));
+        assertEquals(false, KanaAppraiser.isHankakuNumber('\\'));
+        assertEquals(false, KanaAppraiser.isHankakuLetter('\\'));
+
+        assertEquals(true,  KanaAppraiser.isHankakuAscii ('_'));
+        assertEquals(false, KanaAppraiser.isHankakuNumber('_'));
+        assertEquals(false, KanaAppraiser.isHankakuLetter('_'));
+
+        assertEquals(true,  KanaAppraiser.isHankakuAscii ('`'));
+        assertEquals(false, KanaAppraiser.isHankakuNumber('`'));
+        assertEquals(false, KanaAppraiser.isHankakuLetter('`'));
+
+        assertEquals(true,  KanaAppraiser.isHankakuAscii ('a'));
+        assertEquals(false, KanaAppraiser.isHankakuNumber('a'));
+        assertEquals(true,  KanaAppraiser.isHankakuLetter('a'));
+
+        assertEquals(true,  KanaAppraiser.isHankakuAscii ('b'));
+        assertEquals(false, KanaAppraiser.isHankakuNumber('b'));
+        assertEquals(true,  KanaAppraiser.isHankakuLetter('b'));
+
+        assertEquals(true,  KanaAppraiser.isHankakuAscii ('y'));
+        assertEquals(false, KanaAppraiser.isHankakuNumber('y'));
+        assertEquals(true,  KanaAppraiser.isHankakuLetter('y'));
+
+        assertEquals(true,  KanaAppraiser.isHankakuAscii ('z'));
+        assertEquals(false, KanaAppraiser.isHankakuNumber('z'));
+        assertEquals(true,  KanaAppraiser.isHankakuLetter('z'));
+
+        assertEquals(true,  KanaAppraiser.isHankakuAscii ('{'));
+        assertEquals(false, KanaAppraiser.isHankakuNumber('{'));
+        assertEquals(false, KanaAppraiser.isHankakuLetter('{'));
+
+        assertEquals(true,  KanaAppraiser.isHankakuAscii ('|'));
+        assertEquals(false, KanaAppraiser.isHankakuNumber('|'));
+        assertEquals(false, KanaAppraiser.isHankakuLetter('|'));
+
+        assertEquals(true,  KanaAppraiser.isHankakuAscii ('}'));
+        assertEquals(false, KanaAppraiser.isHankakuNumber('}'));
+        assertEquals(false, KanaAppraiser.isHankakuLetter('}'));
+
+        assertEquals(true,  KanaAppraiser.isHankakuAscii ('~'));
+        assertEquals(false, KanaAppraiser.isHankakuNumber('~'));
+        assertEquals(false, KanaAppraiser.isHankakuLetter('~'));
+
+        assertEquals(false, KanaAppraiser.isHankakuAscii ('¡'));
+        assertEquals(false, KanaAppraiser.isHankakuNumber('¡'));
+        assertEquals(false, KanaAppraiser.isHankakuLetter('¡'));
+    }
+    //}}}
+}

--- a/test/mariten/kanatools/TestsKanaAppraiser/KanaBooleanChecksTest.java
+++ b/test/mariten/kanatools/TestsKanaAppraiser/KanaBooleanChecksTest.java
@@ -1,0 +1,75 @@
+package mariten.kanatools.KanaAppraiserTests;
+import mariten.kanatools.KanaAppraiser;
+import mariten.kanatools.KanaAppraiserTester;
+import org.junit.Test;
+
+import static org.junit.Assert.*;
+
+public class KanaBooleanChecksTest extends KanaAppraiserTester
+{
+    //{{{ testZenkakuHiraganaChecks()
+    @Test
+    public void testZenkakuHiraganaChecks()
+    {
+        assertEquals(false, KanaAppraiser.isZenkakuHiragana('〶'));
+        assertEquals(true,  KanaAppraiser.isZenkakuHiragana('ぁ'));
+        assertEquals(true,  KanaAppraiser.isZenkakuHiragana('あ'));
+        assertEquals(true,  KanaAppraiser.isZenkakuHiragana('を'));
+        assertEquals(true,  KanaAppraiser.isZenkakuHiragana('ん'));
+        assertEquals(false, KanaAppraiser.isZenkakuHiragana('ゔ'));
+    }
+    //}}}
+
+
+    //{{{ testZenkakuKatakanaChecks()
+    @Test
+    public void testZenkakuKatakanaChecks()
+    {
+        assertEquals(false, KanaAppraiser.isZenkakuKatakana        ('ゞ'));
+        assertEquals(false, KanaAppraiser.isMappableZenkakuKatakana('ゞ'));
+
+        assertEquals(true,  KanaAppraiser.isZenkakuKatakana        ('ァ'));
+        assertEquals(true,  KanaAppraiser.isMappableZenkakuKatakana('ァ'));
+
+        assertEquals(true,  KanaAppraiser.isZenkakuKatakana        ('ア'));
+        assertEquals(true,  KanaAppraiser.isMappableZenkakuKatakana('ア'));
+
+        assertEquals(true,  KanaAppraiser.isZenkakuKatakana        ('ヲ'));
+        assertEquals(true,  KanaAppraiser.isMappableZenkakuKatakana('ヲ'));
+
+        assertEquals(true,  KanaAppraiser.isZenkakuKatakana        ('ン'));
+        assertEquals(true,  KanaAppraiser.isMappableZenkakuKatakana('ン'));
+
+        assertEquals(true,  KanaAppraiser.isZenkakuKatakana        ('ヴ'));
+        assertEquals(false, KanaAppraiser.isMappableZenkakuKatakana('ヴ'));
+
+        assertEquals(true,  KanaAppraiser.isZenkakuKatakana        ('ヵ'));
+        assertEquals(false, KanaAppraiser.isMappableZenkakuKatakana('ヵ'));
+
+        assertEquals(true,  KanaAppraiser.isZenkakuKatakana        ('ヹ'));
+        assertEquals(false, KanaAppraiser.isMappableZenkakuKatakana('ヹ'));
+
+        assertEquals(true,  KanaAppraiser.isZenkakuKatakana        ('ヺ'));
+        assertEquals(false, KanaAppraiser.isMappableZenkakuKatakana('ヺ'));
+
+        assertEquals(false, KanaAppraiser.isZenkakuKatakana        ('・'));
+        assertEquals(false, KanaAppraiser.isMappableZenkakuKatakana('・'));
+    }
+    //}}}
+
+
+    //{{{ testHankakuKatakanaChecks()
+    @Test
+    public void testHankakuKatakanaChecks()
+    {
+        assertEquals(false, KanaAppraiser.isHankakuKatakana('､'));
+        assertEquals(false, KanaAppraiser.isHankakuKatakana('･'));
+        assertEquals(true,  KanaAppraiser.isHankakuKatakana('ｦ'));
+        assertEquals(true,  KanaAppraiser.isHankakuKatakana('ｧ'));
+        assertEquals(true,  KanaAppraiser.isHankakuKatakana('ﾜ'));
+        assertEquals(true,  KanaAppraiser.isHankakuKatakana('ﾝ'));
+        assertEquals(false, KanaAppraiser.isHankakuKatakana('ﾞ'));
+        assertEquals(false, KanaAppraiser.isHankakuKatakana('ﾟ'));
+    }
+    //}}}
+}


### PR DESCRIPTION
## Summary
* Added new class to handle the `is` style boolean checks of whether a given character is any type hankaku/zenkaku kana or ASCII
* Slim `KanaConverter` down a little bit by relying on this new library for checking whether a character is to be converted or not
* Also for `KanaConverter`, use a pre-calculated constant for the change-delta between hankaku and zenkaku ASCII as well as zenkaku hiragana and zenkaku katakana -- instead of calculating this value on the fly on each execution