### PR TITLE
Add Japanese punctuation mark (kutoten) handling to "KanaAppraiser"

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -46,7 +46,7 @@ jacocoTestReport {
     }
 }
 
-// custom tasks for creating source/javadoc jars
+// Custom tasks for creating source/javadoc JARs
 task sourcesJar(type: Jar, dependsOn: classes) {
     classifier = 'sources'
     from sourceSets.main.allJava
@@ -57,7 +57,7 @@ task javadocJar(type: Jar, dependsOn: javadoc) {
     from javadoc.destinationDir
 }
 
-// add javadoc/source jar tasks as artifacts
+// Add javadoc/source jar tasks as artifacts
 artifacts {
     archives sourcesJar, javadocJar
 }

--- a/src/main/java/mariten/kanatools/KanaAppraiser.java
+++ b/src/main/java/mariten/kanatools/KanaAppraiser.java
@@ -8,7 +8,7 @@ public class KanaAppraiser
     // Character set lower/upper bound definitions
     //// Bounds for Hiragana
     public static final char ZENKAKU_HIRAGANA_FIRST = 'ぁ';             // U+3041
-    public static final char ZENKAKU_HIRAGANA_LAST_FOR_MAPPING  = 'ん'; // U+3093
+    public static final char ZENKAKU_HIRAGANA_LAST_FOR_CONVERT  = 'ん'; // U+3093
     public static final char ZENKAKU_HIRAGANA_LAST  = 'ゖ';             // U+3096
 
 
@@ -17,7 +17,7 @@ public class KanaAppraiser
     public static final char HANKAKU_KATAKANA_LAST  = 'ﾝ';              // U+FF9D
 
     public static final char ZENKAKU_KATAKANA_FIRST = 'ァ';             // U+30A1
-    public static final char ZENKAKU_KATAKANA_LAST_FOR_MAPPING  = 'ン'; // U+30F3
+    public static final char ZENKAKU_KATAKANA_LAST_FOR_CONVERT  = 'ン'; // U+30F3
     public static final char ZENKAKU_KATAKANA_LAST  = 'ヺ';             // U+30FA
 
 
@@ -63,11 +63,11 @@ public class KanaAppraiser
     //}}}
 
 
-    //{{{ boolean isMappableZenkakuHiragana(char)
-    public static boolean isMappableZenkakuHiragana(char eval_char)
+    //{{{ boolean isZenkakuHiraganaWithKatakanaEquivalent(char)
+    public static boolean isZenkakuHiraganaWithKatakanaEquivalent(char eval_char)
     {
         if(eval_char >= ZENKAKU_HIRAGANA_FIRST
-        && eval_char <= ZENKAKU_HIRAGANA_LAST_FOR_MAPPING) {
+        && eval_char <= ZENKAKU_HIRAGANA_LAST_FOR_CONVERT) {
             return true;
         }
         return false;
@@ -99,11 +99,11 @@ public class KanaAppraiser
     //}}}
 
 
-    //{{{ boolean isMappableZenkakuKatakana(char)
-    public static boolean isMappableZenkakuKatakana(char eval_char)
+    //{{{ boolean isZenkakuKatakanaWithHiraganaEquivalent(char)
+    public static boolean isZenkakuKatakanaWithHiraganaEquivalent(char eval_char)
     {
         if(eval_char >= ZENKAKU_KATAKANA_FIRST
-        && eval_char <= ZENKAKU_KATAKANA_LAST_FOR_MAPPING) {
+        && eval_char <= ZENKAKU_KATAKANA_LAST_FOR_CONVERT) {
             return true;
         }
         return false;

--- a/src/main/java/mariten/kanatools/KanaAppraiser.java
+++ b/src/main/java/mariten/kanatools/KanaAppraiser.java
@@ -8,7 +8,8 @@ public class KanaAppraiser
     // Character set lower/upper bound definitions
     //// Bounds for Hiragana
     public static final char ZENKAKU_HIRAGANA_FIRST = 'ぁ';             // U+3041
-    public static final char ZENKAKU_HIRAGANA_LAST  = 'ん';             // U+3093
+    public static final char ZENKAKU_HIRAGANA_LAST_FOR_MAPPING  = 'ん'; // U+3093
+    public static final char ZENKAKU_HIRAGANA_LAST  = 'ゖ';             // U+3096
 
 
     //// Bounds for Katakana
@@ -55,6 +56,18 @@ public class KanaAppraiser
     {
         if(eval_char >= ZENKAKU_HIRAGANA_FIRST
         && eval_char <= ZENKAKU_HIRAGANA_LAST) {
+            return true;
+        }
+        return false;
+    }
+    //}}}
+
+
+    //{{{ boolean isMappableZenkakuHiragana(char)
+    public static boolean isMappableZenkakuHiragana(char eval_char)
+    {
+        if(eval_char >= ZENKAKU_HIRAGANA_FIRST
+        && eval_char <= ZENKAKU_HIRAGANA_LAST_FOR_MAPPING) {
             return true;
         }
         return false;

--- a/src/main/java/mariten/kanatools/KanaAppraiser.java
+++ b/src/main/java/mariten/kanatools/KanaAppraiser.java
@@ -21,6 +21,18 @@ public class KanaAppraiser
     public static final char ZENKAKU_KATAKANA_LAST  = 'ヺ';             // U+30FA
 
 
+    //// Bounds for Punctuation (kutoten)
+    public static final char HANKAKU_PUNCTUATION_FIRST = '｡';           // U+FF61
+    public static final char HANKAKU_PUNCTUATION_LAST  = 'ﾟ';           // U+FF9F
+
+    public static final char ZENKAKU_PUNCTUATION_FIRST    = '、';       // U+3001
+    public static final char ZENKAKU_PUNCTUATION_LAST     = '〜';       // U+301C
+    public static final char ZENKAKU_PUNCTUATION_HG_FIRST = '゛';       // U+309B
+    public static final char ZENKAKU_PUNCTUATION_HG_LAST  = 'ゞ';       // U+309E
+    public static final char ZENKAKU_PUNCTUATION_KK_FIRST = '・';       // U+30FB
+    public static final char ZENKAKU_PUNCTUATION_KK_LAST  = 'ヾ';       // U+30FE
+
+
     //// Bounds for Numeric
     public static final char HANKAKU_NUMBER_FIRST = '0';                // U+0030
     public static final char HANKAKU_NUMBER_LAST  = '9';                // U+0039
@@ -104,6 +116,32 @@ public class KanaAppraiser
     {
         if(eval_char >= ZENKAKU_KATAKANA_FIRST
         && eval_char <= ZENKAKU_KATAKANA_LAST_FOR_CONVERT) {
+            return true;
+        }
+        return false;
+    }
+    //}}}
+
+
+    //{{{ boolean isHankakuKutoten(char)
+    public static boolean isHankakuKutoten(char eval_char)
+    {
+        if(eval_char >= HANKAKU_PUNCTUATION_FIRST
+        && eval_char <= HANKAKU_PUNCTUATION_LAST
+        && !isHankakuKatakana(eval_char)) {
+            return true;
+        }
+        return false;
+    }
+    //}}}
+
+
+    //{{{ boolean isZenkakuKutoten(char)
+    public static boolean isZenkakuKutoten(char eval_char)
+    {
+        if((eval_char >= ZENKAKU_PUNCTUATION_FIRST    && eval_char <= ZENKAKU_PUNCTUATION_LAST)
+        || (eval_char >= ZENKAKU_PUNCTUATION_HG_FIRST && eval_char <= ZENKAKU_PUNCTUATION_HG_LAST)
+        || (eval_char >= ZENKAKU_PUNCTUATION_KK_FIRST && eval_char <= ZENKAKU_PUNCTUATION_KK_LAST)) {
             return true;
         }
         return false;

--- a/src/main/java/mariten/kanatools/KanaAppraiser.java
+++ b/src/main/java/mariten/kanatools/KanaAppraiser.java
@@ -22,8 +22,9 @@ public class KanaAppraiser
 
 
     //// Bounds for Punctuation (kutoten)
-    public static final char HANKAKU_PUNCTUATION_FIRST = '｡';           // U+FF61
-    public static final char HANKAKU_PUNCTUATION_LAST  = 'ﾟ';           // U+FF9F
+    public static final char HANKAKU_PUNCTUATION_FIRST  = '｡';          // U+FF61
+    public static final char HANKAKU_PUNCTUATION_LAST   = 'ﾟ';          // U+FF9F
+    public static final char HANKAKU_PUNCTUATION_ONBIKI = 'ｰ';           // U+FF70
 
     public static final char ZENKAKU_PUNCTUATION_FIRST    = '、';       // U+3001
     public static final char ZENKAKU_PUNCTUATION_LAST     = '〜';       // U+301C
@@ -91,7 +92,8 @@ public class KanaAppraiser
     public static boolean isHankakuKatakana(char eval_char)
     {
         if(eval_char >= HANKAKU_KATAKANA_FIRST
-        && eval_char <= HANKAKU_KATAKANA_LAST) {
+        && eval_char <= HANKAKU_KATAKANA_LAST
+        && eval_char != HANKAKU_PUNCTUATION_ONBIKI) {
             return true;
         }
         return false;

--- a/src/main/java/mariten/kanatools/KanaConverter.java
+++ b/src/main/java/mariten/kanatools/KanaConverter.java
@@ -549,7 +549,7 @@ public class KanaConverter
     //{{{ char convertZenkakuHiraganaToZenkakuKatakana(char)
     protected static char convertZenkakuHiraganaToZenkakuKatakana(char target)
     {
-        if(KanaAppraiser.isMappableZenkakuHiragana(target)) {
+        if(KanaAppraiser.isZenkakuHiraganaWithKatakanaEquivalent(target)) {
             return (char)(target + OFFSET_ZENKAKU_HIRAGANA_TO_ZENKAKU_KATAKANA);
         } else {
             return target;
@@ -561,7 +561,7 @@ public class KanaConverter
     //{{{ char convertZenkakuKatakanaToZenkakuHiragana(char)
     protected static char convertZenkakuKatakanaToZenkakuHiragana(char target)
     {
-        if(KanaAppraiser.isMappableZenkakuKatakana(target)) {
+        if(KanaAppraiser.isZenkakuKatakanaWithHiraganaEquivalent(target)) {
             return (char)(target - OFFSET_ZENKAKU_HIRAGANA_TO_ZENKAKU_KATAKANA);
         } else {
             return target;

--- a/src/main/java/mariten/kanatools/KanaConverter.java
+++ b/src/main/java/mariten/kanatools/KanaConverter.java
@@ -549,7 +549,7 @@ public class KanaConverter
     //{{{ char convertZenkakuHiraganaToZenkakuKatakana(char)
     protected static char convertZenkakuHiraganaToZenkakuKatakana(char target)
     {
-        if(KanaAppraiser.isZenkakuHiragana(target)) {
+        if(KanaAppraiser.isMappableZenkakuHiragana(target)) {
             return (char)(target + OFFSET_ZENKAKU_HIRAGANA_TO_ZENKAKU_KATAKANA);
         } else {
             return target;

--- a/src/test/java/mariten/kanatools/TestsKanaAppraiser/KanaBooleanChecksTest.java
+++ b/src/test/java/mariten/kanatools/TestsKanaAppraiser/KanaBooleanChecksTest.java
@@ -92,4 +92,55 @@ public class KanaBooleanChecksTest extends KanaAppraiserTester
         assertEquals(false, KanaAppraiser.isHankakuKatakana('ﾟ'));
     }
     //}}}
+
+
+    //{{{ testZenkakuKutotenChecks()
+    @Test
+    public void testZenkakuKutotenChecks()
+    {
+        assertEquals(false, KanaAppraiser.isZenkakuKutoten('　'));
+        assertEquals(true,  KanaAppraiser.isZenkakuKutoten('、'));
+        assertEquals(true,  KanaAppraiser.isZenkakuKutoten('。'));
+        assertEquals(true,  KanaAppraiser.isZenkakuKutoten('〛'));
+        assertEquals(true,  KanaAppraiser.isZenkakuKutoten('〜'));
+        assertEquals(false, KanaAppraiser.isZenkakuKutoten('〠'));
+        assertEquals(false, KanaAppraiser.isZenkakuKutoten('〡'));
+
+        assertEquals(false, KanaAppraiser.isZenkakuKutoten('ゖ'));
+        assertEquals(true,  KanaAppraiser.isZenkakuKutoten('゛'));
+        assertEquals(true,  KanaAppraiser.isZenkakuKutoten('゜'));
+        assertEquals(true,  KanaAppraiser.isZenkakuKutoten('ゝ'));
+        assertEquals(true,  KanaAppraiser.isZenkakuKutoten('ゞ'));
+        assertEquals(false, KanaAppraiser.isZenkakuKutoten('ゟ'));
+
+        assertEquals(false, KanaAppraiser.isZenkakuKutoten('ヺ'));
+        assertEquals(true,  KanaAppraiser.isZenkakuKutoten('・'));
+        assertEquals(true,  KanaAppraiser.isZenkakuKutoten('ー'));
+        assertEquals(true,  KanaAppraiser.isZenkakuKutoten('ヽ'));
+        assertEquals(true,  KanaAppraiser.isZenkakuKutoten('ヾ'));
+        assertEquals(false, KanaAppraiser.isZenkakuKutoten('ヿ'));
+    }
+    //}}}
+
+
+    //{{{ testHankakuKutotenChecks()
+    @Test
+    public void testHankakuKutotenChecks()
+    {
+        assertEquals(false, KanaAppraiser.isHankakuKutoten('～'));
+        assertEquals(true,  KanaAppraiser.isHankakuKutoten('｡'));
+        assertEquals(true,  KanaAppraiser.isHankakuKutoten('｢'));
+        assertEquals(true,  KanaAppraiser.isHankakuKutoten('｣'));
+        assertEquals(true,  KanaAppraiser.isHankakuKutoten('､'));
+        assertEquals(true,  KanaAppraiser.isHankakuKutoten('･'));
+        assertEquals(false, KanaAppraiser.isHankakuKutoten('ｦ'));
+        assertEquals(false, KanaAppraiser.isHankakuKutoten('ｧ'));
+        assertEquals(false, KanaAppraiser.isHankakuKutoten('ﾜ'));
+        assertEquals(false, KanaAppraiser.isHankakuKutoten('ﾝ'));
+        assertEquals(true,  KanaAppraiser.isHankakuKutoten('ﾞ'));
+        assertEquals(true,  KanaAppraiser.isHankakuKutoten('ﾟ'));
+        assertEquals(true,  KanaAppraiser.isHankakuKutoten('ﾟ'));
+        assertEquals(false, KanaAppraiser.isHankakuKutoten('ﾡ'));
+    }
+    //}}}
 }

--- a/src/test/java/mariten/kanatools/TestsKanaAppraiser/KanaBooleanChecksTest.java
+++ b/src/test/java/mariten/kanatools/TestsKanaAppraiser/KanaBooleanChecksTest.java
@@ -11,12 +11,32 @@ public class KanaBooleanChecksTest extends KanaAppraiserTester
     @Test
     public void testZenkakuHiraganaChecks()
     {
-        assertEquals(false, KanaAppraiser.isZenkakuHiragana('〶'));
-        assertEquals(true,  KanaAppraiser.isZenkakuHiragana('ぁ'));
-        assertEquals(true,  KanaAppraiser.isZenkakuHiragana('あ'));
-        assertEquals(true,  KanaAppraiser.isZenkakuHiragana('を'));
-        assertEquals(true,  KanaAppraiser.isZenkakuHiragana('ん'));
-        assertEquals(false, KanaAppraiser.isZenkakuHiragana('ゔ'));
+        assertEquals(false, KanaAppraiser.isZenkakuHiragana        ('〶'));
+        assertEquals(false, KanaAppraiser.isMappableZenkakuHiragana('〶'));
+
+        assertEquals(true,  KanaAppraiser.isZenkakuHiragana        ('ぁ'));
+        assertEquals(true,  KanaAppraiser.isMappableZenkakuHiragana('ぁ'));
+
+        assertEquals(true,  KanaAppraiser.isZenkakuHiragana        ('あ'));
+        assertEquals(true,  KanaAppraiser.isMappableZenkakuHiragana('あ'));
+
+        assertEquals(true,  KanaAppraiser.isZenkakuHiragana        ('を'));
+        assertEquals(true,  KanaAppraiser.isMappableZenkakuHiragana('を'));
+
+        assertEquals(true,  KanaAppraiser.isZenkakuHiragana        ('ん'));
+        assertEquals(true,  KanaAppraiser.isMappableZenkakuHiragana('ん'));
+
+        assertEquals(true,  KanaAppraiser.isZenkakuHiragana        ('ゔ'));
+        assertEquals(false, KanaAppraiser.isMappableZenkakuHiragana('ゔ'));
+
+        assertEquals(true,  KanaAppraiser.isZenkakuHiragana        ('ゕ'));
+        assertEquals(false, KanaAppraiser.isMappableZenkakuHiragana('ゕ'));
+
+        assertEquals(true,  KanaAppraiser.isZenkakuHiragana        ('ゖ'));
+        assertEquals(false, KanaAppraiser.isMappableZenkakuHiragana('ゖ'));
+
+        assertEquals(false, KanaAppraiser.isZenkakuHiragana        ('゛'));
+        assertEquals(false, KanaAppraiser.isMappableZenkakuHiragana('゛'));
     }
     //}}}
 

--- a/src/test/java/mariten/kanatools/TestsKanaAppraiser/KanaBooleanChecksTest.java
+++ b/src/test/java/mariten/kanatools/TestsKanaAppraiser/KanaBooleanChecksTest.java
@@ -74,6 +74,9 @@ public class KanaBooleanChecksTest extends KanaAppraiserTester
 
         assertEquals(false, KanaAppraiser.isZenkakuKatakana                      ('・'));
         assertEquals(false, KanaAppraiser.isZenkakuKatakanaWithHiraganaEquivalent('・'));
+
+        assertEquals(false, KanaAppraiser.isZenkakuKatakana                      ('ー'));
+        assertEquals(false, KanaAppraiser.isZenkakuKatakanaWithHiraganaEquivalent('ー'));
     }
     //}}}
 
@@ -86,6 +89,7 @@ public class KanaBooleanChecksTest extends KanaAppraiserTester
         assertEquals(false, KanaAppraiser.isHankakuKatakana('･'));
         assertEquals(true,  KanaAppraiser.isHankakuKatakana('ｦ'));
         assertEquals(true,  KanaAppraiser.isHankakuKatakana('ｧ'));
+        assertEquals(false, KanaAppraiser.isHankakuKatakana('ｰ'));
         assertEquals(true,  KanaAppraiser.isHankakuKatakana('ﾜ'));
         assertEquals(true,  KanaAppraiser.isHankakuKatakana('ﾝ'));
         assertEquals(false, KanaAppraiser.isHankakuKatakana('ﾞ'));
@@ -135,6 +139,7 @@ public class KanaBooleanChecksTest extends KanaAppraiserTester
         assertEquals(true,  KanaAppraiser.isHankakuKutoten('･'));
         assertEquals(false, KanaAppraiser.isHankakuKutoten('ｦ'));
         assertEquals(false, KanaAppraiser.isHankakuKutoten('ｧ'));
+        assertEquals(true,  KanaAppraiser.isHankakuKutoten('ｰ'));
         assertEquals(false, KanaAppraiser.isHankakuKutoten('ﾜ'));
         assertEquals(false, KanaAppraiser.isHankakuKutoten('ﾝ'));
         assertEquals(true,  KanaAppraiser.isHankakuKutoten('ﾞ'));

--- a/src/test/java/mariten/kanatools/TestsKanaAppraiser/KanaBooleanChecksTest.java
+++ b/src/test/java/mariten/kanatools/TestsKanaAppraiser/KanaBooleanChecksTest.java
@@ -11,32 +11,32 @@ public class KanaBooleanChecksTest extends KanaAppraiserTester
     @Test
     public void testZenkakuHiraganaChecks()
     {
-        assertEquals(false, KanaAppraiser.isZenkakuHiragana        ('〶'));
-        assertEquals(false, KanaAppraiser.isMappableZenkakuHiragana('〶'));
+        assertEquals(false, KanaAppraiser.isZenkakuHiragana                      ('〶'));
+        assertEquals(false, KanaAppraiser.isZenkakuHiraganaWithKatakanaEquivalent('〶'));
 
-        assertEquals(true,  KanaAppraiser.isZenkakuHiragana        ('ぁ'));
-        assertEquals(true,  KanaAppraiser.isMappableZenkakuHiragana('ぁ'));
+        assertEquals(true,  KanaAppraiser.isZenkakuHiragana                      ('ぁ'));
+        assertEquals(true,  KanaAppraiser.isZenkakuHiraganaWithKatakanaEquivalent('ぁ'));
 
-        assertEquals(true,  KanaAppraiser.isZenkakuHiragana        ('あ'));
-        assertEquals(true,  KanaAppraiser.isMappableZenkakuHiragana('あ'));
+        assertEquals(true,  KanaAppraiser.isZenkakuHiragana                      ('あ'));
+        assertEquals(true,  KanaAppraiser.isZenkakuHiraganaWithKatakanaEquivalent('あ'));
 
-        assertEquals(true,  KanaAppraiser.isZenkakuHiragana        ('を'));
-        assertEquals(true,  KanaAppraiser.isMappableZenkakuHiragana('を'));
+        assertEquals(true,  KanaAppraiser.isZenkakuHiragana                      ('を'));
+        assertEquals(true,  KanaAppraiser.isZenkakuHiraganaWithKatakanaEquivalent('を'));
 
-        assertEquals(true,  KanaAppraiser.isZenkakuHiragana        ('ん'));
-        assertEquals(true,  KanaAppraiser.isMappableZenkakuHiragana('ん'));
+        assertEquals(true,  KanaAppraiser.isZenkakuHiragana                      ('ん'));
+        assertEquals(true,  KanaAppraiser.isZenkakuHiraganaWithKatakanaEquivalent('ん'));
 
-        assertEquals(true,  KanaAppraiser.isZenkakuHiragana        ('ゔ'));
-        assertEquals(false, KanaAppraiser.isMappableZenkakuHiragana('ゔ'));
+        assertEquals(true,  KanaAppraiser.isZenkakuHiragana                      ('ゔ'));
+        assertEquals(false, KanaAppraiser.isZenkakuHiraganaWithKatakanaEquivalent('ゔ'));
 
-        assertEquals(true,  KanaAppraiser.isZenkakuHiragana        ('ゕ'));
-        assertEquals(false, KanaAppraiser.isMappableZenkakuHiragana('ゕ'));
+        assertEquals(true,  KanaAppraiser.isZenkakuHiragana                      ('ゕ'));
+        assertEquals(false, KanaAppraiser.isZenkakuHiraganaWithKatakanaEquivalent('ゕ'));
 
-        assertEquals(true,  KanaAppraiser.isZenkakuHiragana        ('ゖ'));
-        assertEquals(false, KanaAppraiser.isMappableZenkakuHiragana('ゖ'));
+        assertEquals(true,  KanaAppraiser.isZenkakuHiragana                      ('ゖ'));
+        assertEquals(false, KanaAppraiser.isZenkakuHiraganaWithKatakanaEquivalent('ゖ'));
 
-        assertEquals(false, KanaAppraiser.isZenkakuHiragana        ('゛'));
-        assertEquals(false, KanaAppraiser.isMappableZenkakuHiragana('゛'));
+        assertEquals(false, KanaAppraiser.isZenkakuHiragana                      ('゛'));
+        assertEquals(false, KanaAppraiser.isZenkakuHiraganaWithKatakanaEquivalent('゛'));
     }
     //}}}
 
@@ -45,35 +45,35 @@ public class KanaBooleanChecksTest extends KanaAppraiserTester
     @Test
     public void testZenkakuKatakanaChecks()
     {
-        assertEquals(false, KanaAppraiser.isZenkakuKatakana        ('ゞ'));
-        assertEquals(false, KanaAppraiser.isMappableZenkakuKatakana('ゞ'));
+        assertEquals(false, KanaAppraiser.isZenkakuKatakana                      ('ゞ'));
+        assertEquals(false, KanaAppraiser.isZenkakuKatakanaWithHiraganaEquivalent('ゞ'));
 
-        assertEquals(true,  KanaAppraiser.isZenkakuKatakana        ('ァ'));
-        assertEquals(true,  KanaAppraiser.isMappableZenkakuKatakana('ァ'));
+        assertEquals(true,  KanaAppraiser.isZenkakuKatakana                      ('ァ'));
+        assertEquals(true,  KanaAppraiser.isZenkakuKatakanaWithHiraganaEquivalent('ァ'));
 
-        assertEquals(true,  KanaAppraiser.isZenkakuKatakana        ('ア'));
-        assertEquals(true,  KanaAppraiser.isMappableZenkakuKatakana('ア'));
+        assertEquals(true,  KanaAppraiser.isZenkakuKatakana                      ('ア'));
+        assertEquals(true,  KanaAppraiser.isZenkakuKatakanaWithHiraganaEquivalent('ア'));
 
-        assertEquals(true,  KanaAppraiser.isZenkakuKatakana        ('ヲ'));
-        assertEquals(true,  KanaAppraiser.isMappableZenkakuKatakana('ヲ'));
+        assertEquals(true,  KanaAppraiser.isZenkakuKatakana                      ('ヲ'));
+        assertEquals(true,  KanaAppraiser.isZenkakuKatakanaWithHiraganaEquivalent('ヲ'));
 
-        assertEquals(true,  KanaAppraiser.isZenkakuKatakana        ('ン'));
-        assertEquals(true,  KanaAppraiser.isMappableZenkakuKatakana('ン'));
+        assertEquals(true,  KanaAppraiser.isZenkakuKatakana                      ('ン'));
+        assertEquals(true,  KanaAppraiser.isZenkakuKatakanaWithHiraganaEquivalent('ン'));
 
-        assertEquals(true,  KanaAppraiser.isZenkakuKatakana        ('ヴ'));
-        assertEquals(false, KanaAppraiser.isMappableZenkakuKatakana('ヴ'));
+        assertEquals(true,  KanaAppraiser.isZenkakuKatakana                      ('ヴ'));
+        assertEquals(false, KanaAppraiser.isZenkakuKatakanaWithHiraganaEquivalent('ヴ'));
 
-        assertEquals(true,  KanaAppraiser.isZenkakuKatakana        ('ヵ'));
-        assertEquals(false, KanaAppraiser.isMappableZenkakuKatakana('ヵ'));
+        assertEquals(true,  KanaAppraiser.isZenkakuKatakana                      ('ヵ'));
+        assertEquals(false, KanaAppraiser.isZenkakuKatakanaWithHiraganaEquivalent('ヵ'));
 
-        assertEquals(true,  KanaAppraiser.isZenkakuKatakana        ('ヹ'));
-        assertEquals(false, KanaAppraiser.isMappableZenkakuKatakana('ヹ'));
+        assertEquals(true,  KanaAppraiser.isZenkakuKatakana                      ('ヹ'));
+        assertEquals(false, KanaAppraiser.isZenkakuKatakanaWithHiraganaEquivalent('ヹ'));
 
-        assertEquals(true,  KanaAppraiser.isZenkakuKatakana        ('ヺ'));
-        assertEquals(false, KanaAppraiser.isMappableZenkakuKatakana('ヺ'));
+        assertEquals(true,  KanaAppraiser.isZenkakuKatakana                      ('ヺ'));
+        assertEquals(false, KanaAppraiser.isZenkakuKatakanaWithHiraganaEquivalent('ヺ'));
 
-        assertEquals(false, KanaAppraiser.isZenkakuKatakana        ('・'));
-        assertEquals(false, KanaAppraiser.isMappableZenkakuKatakana('・'));
+        assertEquals(false, KanaAppraiser.isZenkakuKatakana                      ('・'));
+        assertEquals(false, KanaAppraiser.isZenkakuKatakanaWithHiraganaEquivalent('・'));
     }
     //}}}
 


### PR DESCRIPTION
## Summary
* Needed to address issue ( #16 ) that **KanaAppraiser** returned `false` for some characters inside the Hiragana and Katakana Unicode blocks
    * These characters such as the *nakaguro* `・` and the iterative mark `ゞ` are not actually hiragana or katakana per say, but are punctuation marks
    * Best not to have **KanaAppraiser** approve these characters as hiragana/katakana even though they are in the correspoding Unicode blocks.  It would be incorrect, plus it would effect existing code using either **KanaConverter**
* Decided to add a `isZenkakuKutoten` and `isHankakuKutoten` function to **KanaAppraiser**
    * This way it can appraiser an additional type of Japanese text -- punctuation marks frequently used in Japanese
    * This solution also allows the clear delineation of hiragana/katakana *characters* vs kutoten *marks*
* Also includes slight refactor and better names for some **KanaAppraiser** constants and functions

## Details
* Both the Hiragana and Katakana Unicode block have four characters near the very end that are punctuation marks which should be handled as Japanese text but not referred to as "hiragana" or "katakana" but instead as "kutoten" (punctuation):
    * [Hiragana Unicode Block](https://en.wikipedia.org/wiki/Hiragana_%28Unicode_block%29)
    * [Katakana Unicode Block](https://en.wikipedia.org/wiki/Katakana_%28Unicode_block%29)
* The Hankaku Katakana block similarly has some punctuation mixed in:
    * [Hankaku (Half-width) Katakana Unicode Block](https://en.wikipedia.org/wiki/Half-width_kana#Half-width_table)
* Change **KanaAppraiser** so that the punctuation marks mentioned above, as well as those marks frequently used in Japanese text in the below char (`U+FF61` through `U+FF9F`) are appraised as *kutoten* (Japanese punctuation marks)
    * [Full-width Kutoten (Japanese Punctuation) Unicode Reference](http://www.asahi-net.or.jp/~ax2s-kmtn/ref/unicode/u3000.html)